### PR TITLE
Avoid adding the defaultSE a second time in the list of replicas

### DIFF
--- a/src/VIPServer.java
+++ b/src/VIPServer.java
@@ -64,7 +64,7 @@ public class VIPServer extends Process {
 
 	public static SE getSEbyName(String seName) {
 		for (SE se : seList)
-			if (se.getName().matches(seName))
+			if (se.getName().compareToIgnoreCase(seName)==0)
 				return se;
 		// Some worker may define a close SE that was never used, hence that
 		// exists neither in the platform nor the deployment files. In that case


### PR DESCRIPTION
The defaultSE could have been added multiple times it it already belonged to the list of SEs and if another SE (e.g., ophelia) was not present in the platform
