### PR TITLE
modify VIPServer in order to take into account the start_time for Merge

### DIFF
--- a/src/Gate.java
+++ b/src/Gate.java
@@ -144,10 +144,13 @@ public class Gate extends Job {
 
 				nbParticles += simulatedParticles;
 
-				Msg.info("Sending computed number of particles to 'VIPServer'");
-				sendProgress(simulatedParticles);
+				// if dynamic, Gate send Progress to VIPServer; otherwise, enter "END" directly 
+				if(VIPSimulator.workflowVersion.equals("dynamic")){
+					Msg.info("Sending computed number of particles to 'VIPServer'");
+					sendProgress(simulatedParticles);
+					break;
+				}
 
-				break;
 			case "END":
 				Msg.info("Stopping Gate job and uploading results. " + nbParticles + 
 						" particles have been simulated by '" + getName() + "'");

--- a/src/VIPServer.java
+++ b/src/VIPServer.java
@@ -107,24 +107,6 @@ public class VIPServer extends Process {
 					// SHOULD BE REPLACED BY
 					// job.carryOn();
 				} else {
-					if (!timer) {
-						Msg.info("The expected number of particles has been reached. Start a timer!");
-						new Process(this.getHost(), "Timer") {
-							public void main(String[] args) throws HostFailureException {
-								Process.sleep(VIPSimulator.sosTime);
-								if (runningMergeWorkers < VIPSimulator.numberOfMergeJobs) {
-									Msg.info("Timeout has expired. Wake up " + mergeWorkers.size() 
-											+ " Merge worker(s)");
-
-									mergeWorkers.firstElement().begin();
-									runningMergeWorkers++;
-								} else {
-									Msg.info("No need for Merge workers on timeout expiration");
-								}
-							}
-						}.start();
-						timer = true;
-					}
 					job.end();
 				}
 				break;
@@ -139,10 +121,27 @@ public class VIPServer extends Process {
 					if (VIPSimulator.numberOfMergeJobs == 0)
 						stop = true;
 					if (runningMergeWorkers < VIPSimulator.numberOfMergeJobs) {
-						Msg.info("All GATE workers sent a 'GATE_END' message. Wake up " + mergeWorkers.size()
-								+ " Merge worker(s)");
-						runningMergeWorkers++;
-						mergeWorkers.firstElement().begin();
+
+						new Process(this.getHost(), "Timer") {
+							public void main(String[] args) throws HostFailureException {
+								Process.sleep(VIPSimulator.sosTime);
+								boolean mergeFlag = false;
+								while (runningMergeWorkers < VIPSimulator.numberOfMergeJobs) {							
+									while(!mergeFlag){
+										if(mergeWorkers.size() > 0){
+											mergeWorkers.get(runningMergeWorkers).begin();
+											runningMergeWorkers++;
+											mergeFlag = true;
+										}
+										else Process.sleep(10);
+									}
+									Msg.info("All GATE workers sent a 'GATE_END' message. Wake up " + mergeWorkers.size()
+									+ " Merge worker(s)");
+
+								} 
+							}
+						}.start();
+						
 					}
 				}
 				break;
@@ -157,6 +156,8 @@ public class VIPServer extends Process {
 				job.kill();
 				// then stop
 				stop = true;
+				runningMergeWorkers--;
+				
 				break;
 			default:
 				break;

--- a/src/VIPSimulator.java
+++ b/src/VIPSimulator.java
@@ -20,7 +20,8 @@ public class VIPSimulator {
 	public static double eventsPerSec;
 	public static int version;
 	public static long fixedFileSize;
-
+	public static String workflowVersion; 
+	
 	public static void main(String[] args) {
 		Msg.init(args);
 		String platform_file = null;
@@ -51,6 +52,8 @@ public class VIPSimulator {
 		Msg.info("PARAMS:   sostime is " + sosTime + ", number of Gate tasks is " + numberOfGateJobs
 				+ ", number of merge tasks is " + numberOfMergeJobs + ", cpu merge time is " + cpuMergeTime);
 
+		workflowVersion = args.length > 10 ? args[10] : "dynamic";
+		
 		// Load the platform description
 		Msg.createEnvironment(platform_file);
 		// and deploy the application

--- a/src/VIPSimulator.java
+++ b/src/VIPSimulator.java
@@ -52,7 +52,7 @@ public class VIPSimulator {
 		Msg.info("PARAMS:   sostime is " + sosTime + ", number of Gate tasks is " + numberOfGateJobs
 				+ ", number of merge tasks is " + numberOfMergeJobs + ", cpu merge time is " + cpuMergeTime);
 
-		workflowVersion = args.length > 10 ? args[10] : "dynamic";
+		workflowVersion = args.length > 12 ? args[10] : "static";
 		
 		// Load the platform description
 		Msg.createEnvironment(platform_file);


### PR DESCRIPTION
This commit aims at resolving the problem if there is a "BEGIN" message sended by VIPServer but the Merge process is still waiting(before Start_time).

I remove the Timer process which was in case "GATE_PROCESS" because we don't need this any more after the modif.

I add a Timer process in case "GATE_DISCONNECT". The functionality that i want to realize is to make VIPServer wait before Merge process starts. And in order to be able to manage more than one Merge jobs(maybe useful in future), i change the "if" to "while" in line 129.  The second "while"(line 130- 137) is used to suspend VIPServer if no merge is ready to run. And i also add "				runningMergeWorkers--" when a Merge job disconnect.







